### PR TITLE
Fix/download translations before upload

### DIFF
--- a/lib/tasks/1.init.js
+++ b/lib/tasks/1.init.js
@@ -12,7 +12,6 @@ const isGitUrl = require( 'is-git-url' )
 const maf = require( '../maf' )
 const ansi = require( '../util/ansi' )
 const getSpinner = require( '../util/spinner' )
-const getTranslations = require( '../../scripts/translations' )
 
 const { promisify } = require( 'util' )
 
@@ -25,7 +24,6 @@ async function init() {
   const path = `${process.cwd()}/contents`
 
   const language = await getLanguageFromIP()
-  await getTranslations()
 
   const answers = await getAnswers()
   const metadata = createMetadata( answers )

--- a/lib/tasks/4.upload.js
+++ b/lib/tasks/4.upload.js
@@ -9,6 +9,7 @@ const retry = require( 'async-retry' )
 const maf = require( '../maf' )
 const ansi = require( '../util/ansi' )
 const getSpinner = require( '../util/spinner' )
+const downloadTranslations = require('../../scripts/translations')
 
 const now = +new Date
 
@@ -34,7 +35,7 @@ async function upload( done ) {
   const form = new FormData()
   form.append( `file`, fileRead )
 
-  const translations = getTranslations()
+  const translations = await getTranslations()
 
   try {
     await doUpload( form, translations )
@@ -52,7 +53,8 @@ upload.description = `Upload your (zipped) MAF App to the Metrological Dashboard
 
 maf.task( upload )
 
-function getTranslations() {
+async function getTranslations() {
+  await downloadTranslations()
   return require( path.resolve( __dirname, `../resources/translation.json` ) )
 }
 


### PR DESCRIPTION
The `maf upload` task needs `translation.json` but this file is not downloaded when we do a fresh checkout of our MAF project.

Moved `getTranslations()` from `1.init.js` to `4.upload.js`. This is the only place where it is needed.

Now we can upload our project like this without needing to run `maf init` and overwriting our config.

```
git clone <our project>
npm install
maf upload
```